### PR TITLE
Adding a `matcher` property to actions and passing the search string to `handler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Add passing the search query to the action handler for dynamic handling
+
+- Add a `matcher` property to actions to allow dynamic matching
 
 ## 1.2.0 (2022-04-21)
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ Add the tag to your HTML.
       },
     },
     {
+      id: 'Users',
+      title: 'Go to user profile',
+      icon: 'person',
+      matcher: (searchQuery) => searchQuery.match(/.+@.+/),
+      handler: (action, searchQuery) => {
+        // simple handler
+        alert(`Visiting user profile: ${searchQuery}`);
+      },
+    },
+    {
       id: 'Theme',
       title: 'Change theme...',
       icon: 'desktop_windows',
@@ -169,6 +179,7 @@ Array of `INinjaAction` - interface properties below
 | title    | string                  | Title of action                                                                        |
 | hotkey   | string(optional)        | Shortcut to display and register                                                       |
 | handler  | Function(optional)      | Function to execute on select                                                          |
+| matcher  | Function(optional)      | Function to execute on search. Return true if action should be displayed               |
 | mdIcon   | string(optional)        | Material Design font icon name                                                         |
 | icon     | string(optional)        | Html to render as custom icon                                                          |
 | parent   | string(optional)        | If using flat structure use id of actions to make a multilevel menu                    |

--- a/dev/index.html
+++ b/dev/index.html
@@ -110,6 +110,16 @@
       },
       //
       {
+        id: 'Go to User',
+        title: 'Go to user profile',
+        mdIcon: 'person',
+        matcher: (searchQuery) => searchQuery.match(/.+@.+/),
+        handler: (action, searchQuery) => {
+          alert(`Visiting user profile: ${searchQuery}`);
+        },
+      },
+      //
+      {
         id: 'Theme',
         title: 'Change theme...',
         mdIcon: 'desktop_windows',

--- a/docs/index.html
+++ b/docs/index.html
@@ -151,6 +151,16 @@
           },
         },
         {
+          id: 'Users',
+          title: 'Visit user profile',
+          mdIcon: 'person',
+          matcher: (searchQuery) => searchQuery.match(/.+@.+/),
+          handler: (action, searchQuery) => {
+            // simple handler
+            alert(`Visiting user profile: ${searchQuery}`);
+          },
+        },
+        {
           id: 'Theme',
           title: 'Change theme...',
           mdIcon: 'desktop_windows',

--- a/src/interfaces/ininja-action.ts
+++ b/src/interfaces/ininja-action.ts
@@ -3,6 +3,7 @@ export interface INinjaAction {
   title: string;
   hotkey?: string;
   handler?: Function;
+  matcher?: Function;
   mdIcon?: string;
   icon?: string;
   parent?: string;

--- a/src/ninja-keys.ts
+++ b/src/ninja-keys.ts
@@ -362,8 +362,13 @@ export class NinjaKeys extends LitElement {
 
     const actionMatches = this._flatData.filter((action) => {
       const regex = new RegExp(this._search, 'gi');
-      const matcher =
-        action.title.match(regex) || action.keywords?.match(regex);
+      let matcher;
+      if (action.matcher) {
+        matcher = action.matcher(this._search);
+      }
+      else {
+        matcher = action.title.match(regex) || action.keywords?.match(regex);
+      }
 
       if (!this._currentRoot && this._search) {
         // global search for items on root
@@ -468,7 +473,7 @@ export class NinjaKeys extends LitElement {
     this._headerRef.value!.focusSearch();
 
     if (action.handler) {
-      const result = action.handler(action);
+      const result = action.handler(action, this._search);
       if (!result?.keepOpen) {
         this.close();
       }


### PR DESCRIPTION
This pull request adds a `matcher` property to actions that allows for dynamic matching of actions. The `matcher` property can be a function that receives the search string and returns a boolean indicating whether the action should be executed.

When the `matcher` function is defined, the search will only use it and not match on the title or keywords of the action.

It also passes the search string to the `handler` function, so that the handler can use it to perform actions.

Both additions allow actions based on the search string, like jumping to resources (user, project, …) pages. Coupled with semantic [object IDs](https://dev.to/stripe/designing-apis-for-humans-object-ids-3o5a) this can open the gate to a lot of possibilities.